### PR TITLE
Fix resource resolution

### DIFF
--- a/src/main/java/io/jenkins/plugins/ionicons/Ionicons.java
+++ b/src/main/java/io/jenkins/plugins/ionicons/Ionicons.java
@@ -25,7 +25,7 @@ public final class Ionicons {
     private static final String[] SVG_FILE_FORMAT = { "svg" };
     private static final String SVG_FILE_ENDING = "." + SVG_FILE_FORMAT[0];
     private static final String IMAGES_SYMBOLS_PATH = "images/symbols/";
-    private static final String IONICONS_API_PLUGIN = "ionicons-api-plugin";
+    private static final String IONICONS_API_PLUGIN = "ionicons-api";
     private static final String ICON_CLASS_NAME_PATTERN = "symbol-%s plugin-ionicons-api";
 
     private static final Ionicons INSTANCE = new Ionicons();


### PR DESCRIPTION
The jar file of the plugin does not include the `-plugin` part in its name. The resulting URL pointing to the plugin in classpath when running Jenkins thus don't include it neither. The tests worked fine since they picked up the repository folders name - which does include it. I just found out when trying to implement the method. I'm sorry for that oversight on my end.